### PR TITLE
feat: adding ec2 ssh support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,14 @@ module "captain" {
   availability_zones = ["us-west-2a", "us-west-2b"]
   node_pools = [
 #    {
-#      "ami_image_id" : "amazon-eks-node-1.27-v20230607",
+#      "ami_release_version" : "1.27.1-20230703",
 #      "instance_type" : "t3a.large",
 #      "name" : "clusterwide-node-pool-1",
 #      "node_count" : 3,
 #      "spot" : false,
 #      "disk_size_gb" : 20,
-#      "max_pods" : 110
+#      "max_pods" : 110,
+#      "ssh_key_pair_names" : []
 #    }
   ]
   peering_configs = [
@@ -146,7 +147,7 @@ No requirements.
 | <a name="input_csi_driver_version"></a> [csi\_driver\_version](#input\_csi\_driver\_version) | You should grab the appropriate version number from: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG.md | `string` | `"v1.20.0-eksbuild.1"` | no |
 | <a name="input_eks_version"></a> [eks\_version](#input\_eks\_version) | The version of EKS to deploy | `string` | `"1.27"` | no |
 | <a name="input_iam_role_to_assume"></a> [iam\_role\_to\_assume](#input\_iam\_role\_to\_assume) | The full ARN of the IAM role to assume | `string` | n/a | yes |
-| <a name="input_node_pools"></a> [node\_pools](#input\_node\_pools) | node pool configurations:<br>  - name (string): Name of the node pool. MUST BE UNIQUE! Recommended to use YYYYMMDD in the name<br>  - node\_count (number): number of nodes to create in the node pool.<br>  - instance\_type (string): Instance type to use for the nodes. ref: https://instances.vantage.sh/<br>  - ami\_image\_id (string): AMI to use for EKS worker nodes. ref: https://github.com/awslabs/amazon-eks-ami/releases<br>  - spot (bool): Enable spot instances for the nodes. DO NOT ENABLE IN PROD!<br>  - disk\_size\_gb (number): Disk size in GB for the nodes.<br>  - max\_pods (number): max pods that can be scheduled per node. | <pre>list(object({<br>    name          = string<br>    node_count    = number<br>    instance_type = string<br>    ami_image_id  = string<br>    spot          = bool<br>    disk_size_gb  = number<br>    max_pods      = number<br>  }))</pre> | <pre>[<br>  {<br>    "ami_image_id": "amazon-eks-node-1.27-v20230607",<br>    "disk_size_gb": 20,<br>    "instance_type": "t3a.large",<br>    "max_pods": 110,<br>    "name": "default-pool",<br>    "node_count": 1,<br>    "spot": false<br>  }<br>]</pre> | no |
+| <a name="input_node_pools"></a> [node\_pools](#input\_node\_pools) | node pool configurations:<br>  - name (string): Name of the node pool. MUST BE UNIQUE! Recommended to use YYYYMMDD in the name<br>  - node\_count (number): number of nodes to create in the node pool.<br>  - instance\_type (string): Instance type to use for the nodes. ref: https://instances.vantage.sh/<br>  - ami\_release\_version (string): AMI release version to use for EKS worker nodes. ref: https://github.com/awslabs/amazon-eks-ami/releases<br>  - spot (bool): Enable spot instances for the nodes. DO NOT ENABLE IN PROD!<br>  - disk\_size\_gb (number): Disk size in GB for the nodes.<br>  - max\_pods (number): max pods that can be scheduled per node.<br>  - ssh\_key\_pair\_names (list(string)): List of SSH key pair names to associate with the nodes. ref: https://us-west-2.console.aws.amazon.com/ec2/home?region=us-west-2#KeyPairs: | <pre>list(object({<br>    name                = string<br>    node_count          = number<br>    instance_type       = string<br>    ami_release_version = string<br>    spot                = bool<br>    disk_size_gb        = number<br>    max_pods            = number<br>    ssh_key_pair_names  = list(string)<br>  }))</pre> | <pre>[<br>  {<br>    "ami_release_version": "1.27.1-20230703",<br>    "disk_size_gb": 20,<br>    "instance_type": "t3a.large",<br>    "max_pods": 110,<br>    "name": "default-pool",<br>    "node_count": 1,<br>    "spot": false,<br>    "ssh_key_pair_names": []<br>  }<br>]</pre> | no |
 | <a name="input_peering_configs"></a> [peering\_configs](#input\_peering\_configs) | A list of maps containing VPC peering configuration details | <pre>list(object({<br>    vpc_peering_connection_id = string<br>    destination_cidr_block    = string<br>  }))</pre> | `[]` | no |
 | <a name="input_region"></a> [region](#input\_region) | The AWS region to deploy into | `string` | n/a | yes |
 | <a name="input_vpc_cidr_block"></a> [vpc\_cidr\_block](#input\_vpc\_cidr\_block) | The CIDR block for the VPC | `string` | `"10.65.0.0/26"` | no |

--- a/docs/.header.md
+++ b/docs/.header.md
@@ -30,6 +30,7 @@ module "captain" {
 #      "spot" : false,
 #      "disk_size_gb" : 20,
 #      "max_pods" : 110
+#      "ssh_key_pair_names" : []
 #    }
   ]
   peering_configs = [

--- a/docs/.header.md
+++ b/docs/.header.md
@@ -29,7 +29,7 @@ module "captain" {
 #      "node_count" : 3,
 #      "spot" : false,
 #      "disk_size_gb" : 20,
-#      "max_pods" : 110
+#      "max_pods" : 110,
 #      "ssh_key_pair_names" : []
 #    }
   ]

--- a/docs/.header.md
+++ b/docs/.header.md
@@ -23,7 +23,7 @@ module "captain" {
   availability_zones = ["us-west-2a", "us-west-2b"]
   node_pools = [
 #    {
-#      "ami_image_id" : "amazon-eks-node-1.27-v20230607",
+#      "ami_release_version" : "1.27.1-20230703",
 #      "instance_type" : "t3a.large",
 #      "name" : "clusterwide-node-pool-1",
 #      "node_count" : 3,

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ module "node_pool" {
   max_size         = each.value.node_count + 1
   cluster_name     = module.kubernetes.eks_cluster_id
   capacity_type    = each.value.spot ? "SPOT" : "ON_DEMAND"
-  ami_release_version     = "1.27-v20230607"
+  ami_release_version     = ["1.27-v20230607"]
 
   cluster_autoscaler_enabled = false
   name                       = each.value.name

--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,7 @@ module "node_pool" {
   max_size         = each.value.node_count + 1
   cluster_name     = module.kubernetes.eks_cluster_id
   capacity_type    = each.value.spot ? "SPOT" : "ON_DEMAND"
+  ami_image_id     = each.value.ami_image_id
 
   cluster_autoscaler_enabled = false
   name                       = each.value.name

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ module "node_pool" {
   max_size         = each.value.node_count + 1
   cluster_name     = module.kubernetes.eks_cluster_id
   capacity_type    = each.value.spot ? "SPOT" : "ON_DEMAND"
-  ami_image_id     = each.value.ami_image_id
+  ami_image_id     = [each.value.ami_image_id]
 
   cluster_autoscaler_enabled = false
   name                       = each.value.name

--- a/main.tf
+++ b/main.tf
@@ -14,9 +14,9 @@ module "kubernetes" {
   source  = "cloudposse/eks-cluster/aws"
   version = "2.8.1"
 
-  region            = var.region
-  vpc_id            = module.vpc.vpc_id
-  subnet_ids        = module.subnets.public_subnet_ids
+  region     = var.region
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.subnets.public_subnet_ids
 
   oidc_provider_enabled      = true
   name                       = "captain"
@@ -29,15 +29,15 @@ module "node_pool" {
   for_each = { for np in var.node_pools : np.name => np }
   source   = "cloudposse/eks-node-group/aws"
   # Cloud Posse recommends pinning every module to a specific version
-  version = "2.10.0"
-
-  instance_types = [each.value.instance_type]
-  subnet_ids     = module.subnets.public_subnet_ids
-  desired_size   = each.value.node_count
-  min_size       = each.value.node_count
-  max_size       = each.value.node_count + 1
-  cluster_name   = module.kubernetes.eks_cluster_id
-  capacity_type  = each.value.spot ? "SPOT" : "ON_DEMAND"
+  version          = "2.10.0"
+  ec2_ssh_key_name = each.value.ssh_key_pair_names
+  instance_types   = [each.value.instance_type]
+  subnet_ids       = module.subnets.public_subnet_ids
+  desired_size     = each.value.node_count
+  min_size         = each.value.node_count
+  max_size         = each.value.node_count + 1
+  cluster_name     = module.kubernetes.eks_cluster_id
+  capacity_type    = each.value.spot ? "SPOT" : "ON_DEMAND"
 
   cluster_autoscaler_enabled = false
   name                       = each.value.name

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ module "node_pool" {
   max_size         = each.value.node_count + 1
   cluster_name     = module.kubernetes.eks_cluster_id
   capacity_type    = each.value.spot ? "SPOT" : "ON_DEMAND"
-  ami_release_version     = ["1.27-v20230607"]
+  ami_release_version     = ["1.27-20230607"]
 
   cluster_autoscaler_enabled = false
   name                       = each.value.name

--- a/main.tf
+++ b/main.tf
@@ -29,16 +29,16 @@ module "node_pool" {
   for_each = { for np in var.node_pools : np.name => np }
   source   = "cloudposse/eks-node-group/aws"
   # Cloud Posse recommends pinning every module to a specific version
-  version          = "2.10.0"
-  ec2_ssh_key_name = each.value.ssh_key_pair_names
-  instance_types   = [each.value.instance_type]
-  subnet_ids       = module.subnets.public_subnet_ids
-  desired_size     = each.value.node_count
-  min_size         = each.value.node_count
-  max_size         = each.value.node_count + 1
-  cluster_name     = module.kubernetes.eks_cluster_id
-  capacity_type    = each.value.spot ? "SPOT" : "ON_DEMAND"
-  ami_release_version     = ["1.27.1-20230703"]
+  version             = "2.10.0"
+  ec2_ssh_key_name    = each.value.ssh_key_pair_names
+  instance_types      = [each.value.instance_type]
+  subnet_ids          = module.subnets.public_subnet_ids
+  desired_size        = each.value.node_count
+  min_size            = each.value.node_count
+  max_size            = each.value.node_count + 1
+  cluster_name        = module.kubernetes.eks_cluster_id
+  capacity_type       = each.value.spot ? "SPOT" : "ON_DEMAND"
+  ami_release_version = [each.value.ami_release_version]
 
   cluster_autoscaler_enabled = false
   name                       = each.value.name

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ module "node_pool" {
   max_size         = each.value.node_count + 1
   cluster_name     = module.kubernetes.eks_cluster_id
   capacity_type    = each.value.spot ? "SPOT" : "ON_DEMAND"
-  ami_release_version     = ["1.27-20230607"]
+  ami_release_version     = ["1.27.1-20230703"]
 
   cluster_autoscaler_enabled = false
   name                       = each.value.name

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ module "node_pool" {
   max_size         = each.value.node_count + 1
   cluster_name     = module.kubernetes.eks_cluster_id
   capacity_type    = each.value.spot ? "SPOT" : "ON_DEMAND"
-  ami_image_id     = [each.value.ami_image_id]
+  ami_release_version     = "1.27-v20230607"
 
   cluster_autoscaler_enabled = false
   name                       = each.value.name

--- a/tests/main.tf
+++ b/tests/main.tf
@@ -14,7 +14,7 @@ module "captain" {
     #   "node_count" : 2,
     #   "spot" : false,
     #   "disk_size_gb" : 20,
-    #   "max_pods" : 1000
+    #   "max_pods" : 1000,
     #   "ssh_key_pair_names" : []
     # }
   ]

--- a/tests/main.tf
+++ b/tests/main.tf
@@ -8,7 +8,7 @@ module "captain" {
   availability_zones = ["us-west-2a", "us-west-2b"]
   node_pools = [
     # {
-    #   "ami_image_id" : "amazon-eks-node-1.27-v20230607",
+    #   "ami_release_version" : "1.27.1-20230703",
     #   "instance_type" : "t3a.small",
     #   "name" : "clusterwide-node-pool-1",
     #   "node_count" : 2,

--- a/tests/main.tf
+++ b/tests/main.tf
@@ -1,11 +1,11 @@
 module "captain" {
-  iam_role_to_assume           = "arn:aws:iam::761182885829:role/glueops-captain"
-  source                       = "../"
-  eks_version                  = "1.27"
-  csi_driver_version           = "v1.20.0-eksbuild.1"
-  vpc_cidr_block               = "10.65.0.0/26"
-  region                       = "us-west-2"
-  availability_zones           = ["us-west-2a", "us-west-2b"]
+  iam_role_to_assume = "arn:aws:iam::761182885829:role/glueops-captain"
+  source             = "../"
+  eks_version        = "1.27"
+  csi_driver_version = "v1.20.0-eksbuild.1"
+  vpc_cidr_block     = "10.65.0.0/26"
+  region             = "us-west-2"
+  availability_zones = ["us-west-2a", "us-west-2b"]
   node_pools = [
     # {
     #   "ami_image_id" : "amazon-eks-node-1.27-v20230607",
@@ -15,6 +15,7 @@ module "captain" {
     #   "spot" : false,
     #   "disk_size_gb" : 20,
     #   "max_pods" : 1000
+    #   "ssh_key_pair_names" : []
     # }
   ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -40,13 +40,14 @@ variable "node_pools" {
     ssh_key_pair_names = list(string)
   }))
   default = [{
-    name          = "default-pool"
-    node_count    = 1
-    instance_type = "t3a.large"
-    ami_image_id  = "amazon-eks-node-1.27-v20230607"
-    spot          = false
-    disk_size_gb  = 20
-    max_pods      = 110
+    name               = "default-pool"
+    node_count         = 1
+    instance_type      = "t3a.large"
+    ami_image_id       = "amazon-eks-node-1.27-v20230607"
+    spot               = false
+    disk_size_gb       = 20
+    max_pods           = 110
+    ssh_key_pair_names = []
   }]
   description = <<-DESC
   node pool configurations:

--- a/variables.tf
+++ b/variables.tf
@@ -30,31 +30,31 @@ variable "eks_version" {
 
 variable "node_pools" {
   type = list(object({
-    name               = string
-    node_count         = number
-    instance_type      = string
-    ami_image_id       = string
-    spot               = bool
-    disk_size_gb       = number
-    max_pods           = number
-    ssh_key_pair_names = list(string)
+    name                = string
+    node_count          = number
+    instance_type       = string
+    ami_release_version = string
+    spot                = bool
+    disk_size_gb        = number
+    max_pods            = number
+    ssh_key_pair_names  = list(string)
   }))
   default = [{
-    name               = "default-pool"
-    node_count         = 1
-    instance_type      = "t3a.large"
-    ami_image_id       = "amazon-eks-node-1.27-v20230607"
-    spot               = false
-    disk_size_gb       = 20
-    max_pods           = 110
-    ssh_key_pair_names = []
+    name                = "default-pool"
+    node_count          = 1
+    instance_type       = "t3a.large"
+    ami_release_version = "1.27.1-20230703"
+    spot                = false
+    disk_size_gb        = 20
+    max_pods            = 110
+    ssh_key_pair_names  = []
   }]
   description = <<-DESC
   node pool configurations:
     - name (string): Name of the node pool. MUST BE UNIQUE! Recommended to use YYYYMMDD in the name
     - node_count (number): number of nodes to create in the node pool.
     - instance_type (string): Instance type to use for the nodes. ref: https://instances.vantage.sh/
-    - ami_image_id (string): AMI to use for EKS worker nodes. ref: https://github.com/awslabs/amazon-eks-ami/releases
+    - ami_release_version (string): AMI release version to use for EKS worker nodes. ref: https://github.com/awslabs/amazon-eks-ami/releases
     - spot (bool): Enable spot instances for the nodes. DO NOT ENABLE IN PROD!
     - disk_size_gb (number): Disk size in GB for the nodes.
     - max_pods (number): max pods that can be scheduled per node.

--- a/variables.tf
+++ b/variables.tf
@@ -30,13 +30,14 @@ variable "eks_version" {
 
 variable "node_pools" {
   type = list(object({
-    name          = string
-    node_count    = number
-    instance_type = string
-    ami_image_id  = string
-    spot          = bool
-    disk_size_gb  = number
-    max_pods      = number
+    name               = string
+    node_count         = number
+    instance_type      = string
+    ami_image_id       = string
+    spot               = bool
+    disk_size_gb       = number
+    max_pods           = number
+    ssh_key_pair_names = list(string)
   }))
   default = [{
     name          = "default-pool"
@@ -56,6 +57,7 @@ variable "node_pools" {
     - spot (bool): Enable spot instances for the nodes. DO NOT ENABLE IN PROD!
     - disk_size_gb (number): Disk size in GB for the nodes.
     - max_pods (number): max pods that can be scheduled per node.
+    - ssh_key_pair_names (list(string)): List of SSH key pair names to associate with the nodes. ref: https://us-west-2.console.aws.amazon.com/ec2/home?region=us-west-2#KeyPairs:
   DESC
 }
 


### PR DESCRIPTION
fix: anytime an apply was run it was trying to update to the latest EKS AMI version rather than using the one we provided.
feat: adding support to add SSH Keys to EC2 hosts for logging in and debugging (note: this requires recreation of the nodes and may cause downtime, so create a NEW node pool when adding SSH keys)