### PR TITLE
chore(deps): bump codespace version to v0.42.0

### DIFF
--- a/.github/workflows/aws-cloud-regression-suite.yml
+++ b/.github/workflows/aws-cloud-regression-suite.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup Codespace Container
       run: |
         echo "::group::Setup Codespace Container"
-        docker run -d -v $(pwd):/app --workdir /app/tests --rm --name codespaces ghcr.io/glueops/codespaces:v0.41.1 sleep infinity
+        docker run -d -v $(pwd):/app --workdir /app/tests --rm --name codespaces ghcr.io/glueops/codespaces:v0.42.0 sleep infinity
         echo "::endgroup::"
 
     - name: Running AWS Regression Suite


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the Docker image version in the GitHub Actions workflow to use `ghcr.io/glueops/codespaces:v0.42.0` instead of `v0.41.1`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aws-cloud-regression-suite.yml</strong><dd><code>Update Docker Image Version in GitHub Actions Workflow</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/aws-cloud-regression-suite.yml
<li>Updated the Docker image version used in the Codespace container setup <br>from <code>v0.41.1</code> to <code>v0.42.0</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster/pull/116/files#diff-e490df27c497a7f68f533406a9c586c97dc63277a893961dea02841a6e98ecb5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

