### PR TITLE
feat: update EKS AMI, CSI Driver, Core DNS, and KUbe proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ module "captain" {
   iam_role_to_assume = "arn:aws:iam::1234567890:role/glueops-captain-role"
   source             = "git::https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster.git"
   eks_version        = "1.28"
-  csi_driver_version = "v1.30.0-eksbuild.1"
-  coredns_version    = "v1.10.1-eksbuild.7"
-  kube_proxy_version = "v1.28.6-eksbuild.2"
+  csi_driver_version = "v1.31.0-eksbuild.1"
+  coredns_version    = "v1.10.1-eksbuild.11"
+  kube_proxy_version = "v1.28.8-eksbuild.5"
   vpc_cidr_block     = "10.65.0.0/26"
   region             = "us-west-2"
   availability_zones = ["us-west-2a", "us-west-2b"]
   node_pools = [
 #    {
-#      "ami_image_id" : "ami-04fd8e3a70c3778b2",
+#      "ami_image_id" : "ami-0408823a87d4095d9",
 #      "instance_type" : "t3a.xlarge",
 #      "name" : "glueops-platform-node-pool-1",
 #      "node_count" : 4,
@@ -46,7 +46,7 @@ module "captain" {
 #      ]
 #    },
 #    {
-#      "ami_image_id" : "ami-04fd8e3a70c3778b2",
+#      "ami_image_id" : "ami-0408823a87d4095d9",
 #      "instance_type" : "t3a.xlarge",
 #      "name" : "glueops-platform-node-pool-argocd-app-controller-1",
 #      "node_count" : 2,
@@ -66,7 +66,7 @@ module "captain" {
 #      ]
 #    },
 #    {
-#      "ami_image_id" : "ami-04fd8e3a70c3778b2",
+#      "ami_image_id" : "ami-0408823a87d4095d9",
 #      "instance_type" : "t3a.large",
 #      "name" : "clusterwide-node-pool-1",
 #      "node_count" : 4,
@@ -195,7 +195,7 @@ No requirements.
 | <a name="input_eks_version"></a> [eks\_version](#input\_eks\_version) | The version of EKS to deploy | `string` | `"1.27"` | no |
 | <a name="input_iam_role_to_assume"></a> [iam\_role\_to\_assume](#input\_iam\_role\_to\_assume) | The full ARN of the IAM role to assume | `string` | n/a | yes |
 | <a name="input_kube_proxy_version"></a> [kube\_proxy\_version](#input\_kube\_proxy\_version) | You should grab the appropriate version number from: https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html | `string` | `"v1.28.6-eksbuild.2\t"` | no |
-| <a name="input_node_pools"></a> [node\_pools](#input\_node\_pools) | node pool configurations:<br>  - name (string): Name of the node pool. MUST BE UNIQUE! Recommended to use YYYYMMDD in the name<br>  - node\_count (number): number of nodes to create in the node pool.<br>  - instance\_type (string): Instance type to use for the nodes. ref: https://instances.vantage.sh/<br>  - ami\_image\_id (string): AMI image ID to use for EKS worker nodes. This varies per region!! ref: https://github.com/awslabs/amazon-eks-ami/releases to find the AMI ID go to the console: https://us-west-2.console.aws.amazon.com/ec2/home?region=us-west-2#Images:visibility=public-images;search=amazon-eks-node-1.28-v20230703<br>  - spot (bool): Enable spot instances for the nodes. DO NOT ENABLE IN PROD!<br>  - disk\_size\_gb (number): Disk size in GB for the nodes.<br>  - max\_pods (number): max pods that can be scheduled per node.<br>  - ssh\_key\_pair\_names (list(string)): List of SSH key pair names to associate with the nodes. ref: https://us-west-2.console.aws.amazon.com/ec2/home?region=us-west-2#KeyPairs:<br>  - kubernetes\_labels (map(string)): Map of labels to apply to the nodes. ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/<br>  - kubernetes\_taints (list(object)): List of taints to apply to the nodes. ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ | <pre>list(object({<br>    name               = string<br>    node_count         = number<br>    instance_type      = string<br>    ami_image_id       = string<br>    spot               = bool<br>    disk_size_gb       = number<br>    max_pods           = number<br>    ssh_key_pair_names = list(string)<br>    kubernetes_labels  = map(string)<br>    kubernetes_taints = list(object({<br>      key    = string<br>      value  = string<br>      effect = string<br>    }))<br><br>  }))</pre> | <pre>[<br>  {<br>    "ami_image_id": "ami-04fd8e3a70c3778b2",<br>    "disk_size_gb": 20,<br>    "instance_type": "t3a.large",<br>    "kubernetes_labels": {},<br>    "kubernetes_taints": [],<br>    "max_pods": 110,<br>    "name": "default-pool",<br>    "node_count": 1,<br>    "spot": false,<br>    "ssh_key_pair_names": []<br>  }<br>]</pre> | no |
+| <a name="input_node_pools"></a> [node\_pools](#input\_node\_pools) | node pool configurations:<br>  - name (string): Name of the node pool. MUST BE UNIQUE! Recommended to use YYYYMMDD in the name<br>  - node\_count (number): number of nodes to create in the node pool.<br>  - instance\_type (string): Instance type to use for the nodes. ref: https://instances.vantage.sh/<br>  - ami\_image\_id (string): AMI image ID to use for EKS worker nodes. This varies per region!! ref: https://github.com/awslabs/amazon-eks-ami/releases to find the AMI ID go to the console: https://us-west-2.console.aws.amazon.com/ec2/home?region=us-west-2#Images:visibility=public-images;search=amazon-eks-node-1.28-v20230703<br>  - spot (bool): Enable spot instances for the nodes. DO NOT ENABLE IN PROD!<br>  - disk\_size\_gb (number): Disk size in GB for the nodes.<br>  - max\_pods (number): max pods that can be scheduled per node.<br>  - ssh\_key\_pair\_names (list(string)): List of SSH key pair names to associate with the nodes. ref: https://us-west-2.console.aws.amazon.com/ec2/home?region=us-west-2#KeyPairs:<br>  - kubernetes\_labels (map(string)): Map of labels to apply to the nodes. ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/<br>  - kubernetes\_taints (list(object)): List of taints to apply to the nodes. ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ | <pre>list(object({<br>    name               = string<br>    node_count         = number<br>    instance_type      = string<br>    ami_image_id       = string<br>    spot               = bool<br>    disk_size_gb       = number<br>    max_pods           = number<br>    ssh_key_pair_names = list(string)<br>    kubernetes_labels  = map(string)<br>    kubernetes_taints = list(object({<br>      key    = string<br>      value  = string<br>      effect = string<br>    }))<br><br>  }))</pre> | <pre>[<br>  {<br>    "ami_image_id": "ami-0408823a87d4095d9",<br>    "disk_size_gb": 20,<br>    "instance_type": "t3a.large",<br>    "kubernetes_labels": {},<br>    "kubernetes_taints": [],<br>    "max_pods": 110,<br>    "name": "default-pool",<br>    "node_count": 1,<br>    "spot": false,<br>    "ssh_key_pair_names": []<br>  }<br>]</pre> | no |
 | <a name="input_peering_configs"></a> [peering\_configs](#input\_peering\_configs) | A list of maps containing VPC peering configuration details | <pre>list(object({<br>    vpc_peering_connection_id = string<br>    destination_cidr_block    = string<br>  }))</pre> | `[]` | no |
 | <a name="input_region"></a> [region](#input\_region) | The AWS region to deploy into | `string` | n/a | yes |
 | <a name="input_vpc_cidr_block"></a> [vpc\_cidr\_block](#input\_vpc\_cidr\_block) | The CIDR block for the VPC | `string` | `"10.65.0.0/26"` | no |

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ module "captain" {
   iam_role_to_assume = "arn:aws:iam::1234567890:role/glueops-captain-role"
   source             = "git::https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster.git"
   eks_version        = "1.28"
-  csi_driver_version = "v1.31.0-eksbuild.1"
-  coredns_version    = "v1.10.1-eksbuild.11"
-  kube_proxy_version = "v1.28.8-eksbuild.5"
+  csi_driver_version = "v1.30.0-eksbuild.1"
+  coredns_version    = "v1.10.1-eksbuild.7"
+  kube_proxy_version = "v1.28.6-eksbuild.2"
   vpc_cidr_block     = "10.65.0.0/26"
   region             = "us-west-2"
   availability_zones = ["us-west-2a", "us-west-2b"]
@@ -190,11 +190,11 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | The availability zones to deploy into | `list(string)` | <pre>[<br>  "us-west-2a",<br>  "us-west-2b",<br>  "us-west-2c"<br>]</pre> | no |
-| <a name="input_coredns_version"></a> [coredns\_version](#input\_coredns\_version) | You should grab the appropriate version number from: https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html | `string` | `"v1.10.1-eksbuild.7"` | no |
-| <a name="input_csi_driver_version"></a> [csi\_driver\_version](#input\_csi\_driver\_version) | You should grab the appropriate version number from: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG.md | `string` | `"v1.30.0-eksbuild.1"` | no |
+| <a name="input_coredns_version"></a> [coredns\_version](#input\_coredns\_version) | You should grab the appropriate version number from: https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html | `string` | `"v1.10.1-eksbuild.11"` | no |
+| <a name="input_csi_driver_version"></a> [csi\_driver\_version](#input\_csi\_driver\_version) | You should grab the appropriate version number from: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG.md | `string` | `"v1.31.0-eksbuild.1"` | no |
 | <a name="input_eks_version"></a> [eks\_version](#input\_eks\_version) | The version of EKS to deploy | `string` | `"1.27"` | no |
 | <a name="input_iam_role_to_assume"></a> [iam\_role\_to\_assume](#input\_iam\_role\_to\_assume) | The full ARN of the IAM role to assume | `string` | n/a | yes |
-| <a name="input_kube_proxy_version"></a> [kube\_proxy\_version](#input\_kube\_proxy\_version) | You should grab the appropriate version number from: https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html | `string` | `"v1.28.6-eksbuild.2\t"` | no |
+| <a name="input_kube_proxy_version"></a> [kube\_proxy\_version](#input\_kube\_proxy\_version) | You should grab the appropriate version number from: https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html | `string` | `"v1.28.8-eksbuild.5"` | no |
 | <a name="input_node_pools"></a> [node\_pools](#input\_node\_pools) | node pool configurations:<br>  - name (string): Name of the node pool. MUST BE UNIQUE! Recommended to use YYYYMMDD in the name<br>  - node\_count (number): number of nodes to create in the node pool.<br>  - instance\_type (string): Instance type to use for the nodes. ref: https://instances.vantage.sh/<br>  - ami\_image\_id (string): AMI image ID to use for EKS worker nodes. This varies per region!! ref: https://github.com/awslabs/amazon-eks-ami/releases to find the AMI ID go to the console: https://us-west-2.console.aws.amazon.com/ec2/home?region=us-west-2#Images:visibility=public-images;search=amazon-eks-node-1.28-v20230703<br>  - spot (bool): Enable spot instances for the nodes. DO NOT ENABLE IN PROD!<br>  - disk\_size\_gb (number): Disk size in GB for the nodes.<br>  - max\_pods (number): max pods that can be scheduled per node.<br>  - ssh\_key\_pair\_names (list(string)): List of SSH key pair names to associate with the nodes. ref: https://us-west-2.console.aws.amazon.com/ec2/home?region=us-west-2#KeyPairs:<br>  - kubernetes\_labels (map(string)): Map of labels to apply to the nodes. ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/<br>  - kubernetes\_taints (list(object)): List of taints to apply to the nodes. ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ | <pre>list(object({<br>    name               = string<br>    node_count         = number<br>    instance_type      = string<br>    ami_image_id       = string<br>    spot               = bool<br>    disk_size_gb       = number<br>    max_pods           = number<br>    ssh_key_pair_names = list(string)<br>    kubernetes_labels  = map(string)<br>    kubernetes_taints = list(object({<br>      key    = string<br>      value  = string<br>      effect = string<br>    }))<br><br>  }))</pre> | <pre>[<br>  {<br>    "ami_image_id": "ami-0408823a87d4095d9",<br>    "disk_size_gb": 20,<br>    "instance_type": "t3a.large",<br>    "kubernetes_labels": {},<br>    "kubernetes_taints": [],<br>    "max_pods": 110,<br>    "name": "default-pool",<br>    "node_count": 1,<br>    "spot": false,<br>    "ssh_key_pair_names": []<br>  }<br>]</pre> | no |
 | <a name="input_peering_configs"></a> [peering\_configs](#input\_peering\_configs) | A list of maps containing VPC peering configuration details | <pre>list(object({<br>    vpc_peering_connection_id = string<br>    destination_cidr_block    = string<br>  }))</pre> | `[]` | no |
 | <a name="input_region"></a> [region](#input\_region) | The AWS region to deploy into | `string` | n/a | yes |

--- a/docs/.header.md
+++ b/docs/.header.md
@@ -25,7 +25,7 @@ module "captain" {
   availability_zones = ["us-west-2a", "us-west-2b"]
   node_pools = [
 #    {
-#      "ami_image_id" : "ami-04fd8e3a70c3778b2",
+#      "ami_image_id" : "ami-0408823a87d4095d9",
 #      "instance_type" : "t3a.xlarge",
 #      "name" : "glueops-platform-node-pool-1",
 #      "node_count" : 4,
@@ -45,7 +45,7 @@ module "captain" {
 #      ]
 #    },
 #    {
-#      "ami_image_id" : "ami-04fd8e3a70c3778b2",
+#      "ami_image_id" : "ami-0408823a87d4095d9",
 #      "instance_type" : "t3a.xlarge",
 #      "name" : "glueops-platform-node-pool-argocd-app-controller-1",
 #      "node_count" : 2,
@@ -65,7 +65,7 @@ module "captain" {
 #      ]
 #    },
 #    {
-#      "ami_image_id" : "ami-04fd8e3a70c3778b2",
+#      "ami_image_id" : "ami-0408823a87d4095d9",
 #      "instance_type" : "t3a.large",
 #      "name" : "clusterwide-node-pool-1",
 #      "node_count" : 4,

--- a/tests/main.tf
+++ b/tests/main.tf
@@ -2,15 +2,15 @@ module "captain" {
   iam_role_to_assume = "arn:aws:iam::761182885829:role/glueops-captain-role" 
   source             = "../"
   eks_version        = "1.28"
-  csi_driver_version = "v1.30.0-eksbuild.1"
-  coredns_version    = "v1.10.1-eksbuild.7"
-  kube_proxy_version = "v1.28.6-eksbuild.2"
+  csi_driver_version = "v1.31.0-eksbuild.1"
+  coredns_version    = "v1.10.1-eksbuild.11"
+  kube_proxy_version = "v1.28.8-eksbuild.5"
   vpc_cidr_block     = "10.65.0.0/26"
   region             = "us-west-2"
   availability_zones = ["us-west-2a", "us-west-2b"]
   node_pools = [
 #    {
-#      "ami_image_id" : "ami-04fd8e3a70c3778b2",
+#      "ami_image_id" : "ami-0408823a87d4095d9",
 #      "instance_type" : "t3a.xlarge",
 #      "name" : "glueops-platform-node-pool-1",
 #      "node_count" : 4,
@@ -30,7 +30,7 @@ module "captain" {
 #      ]
 #    },
 #    {
-#      "ami_image_id" : "ami-04fd8e3a70c3778b2",
+#      "ami_image_id" : "ami-0408823a87d4095d9",
 #      "instance_type" : "t3a.xlarge",
 #      "name" : "glueops-platform-node-pool-argocd-app-controller-1",
 #      "node_count" : 2,
@@ -50,7 +50,7 @@ module "captain" {
 #      ]
 #    },
 #    {
-#      "ami_image_id" : "ami-04fd8e3a70c3778b2",
+#      "ami_image_id" : "ami-0408823a87d4095d9",
 #      "instance_type" : "t3a.large",
 #      "name" : "clusterwide-node-pool-1",
 #      "node_count" : 4,

--- a/variables.tf
+++ b/variables.tf
@@ -5,19 +5,19 @@ variable "region" {
 
 variable "csi_driver_version" {
   type        = string
-  default     = "v1.30.0-eksbuild.1"
+  default     = "v1.31.0-eksbuild.1"
   description = "You should grab the appropriate version number from: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG.md"
 }
 
 variable "coredns_version" {
   type        = string
-  default     = "v1.10.1-eksbuild.7"
+  default     = "v1.10.1-eksbuild.11"
   description = "You should grab the appropriate version number from: https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html"
 }
 
 variable "kube_proxy_version" {
   type        = string
-  default     = "v1.28.6-eksbuild.2	"
+  default     = "v1.28.8-eksbuild.5"
   description = "You should grab the appropriate version number from: https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html"
 }
 
@@ -90,7 +90,7 @@ variable "node_pools" {
     name               = "default-pool"
     node_count         = 1
     instance_type      = "t3a.large"
-    ami_image_id       = "ami-04fd8e3a70c3778b2"
+    ami_image_id       = "ami-0408823a87d4095d9"
     spot               = false
     disk_size_gb       = 20
     max_pods           = 110


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation


___

### **Description**
- Updated `csi_driver_version` to `v1.31.0-eksbuild.1`
- Updated `coredns_version` to `v1.10.1-eksbuild.11`
- Updated `kube_proxy_version` to `v1.28.8-eksbuild.5`
- Updated `ami_image_id` for node pools in multiple files
- Updated README and documentation header with new versions and AMI image ID


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Update EKS component versions and AMI image IDs in test configuration</code></dd></summary>
<hr>

tests/main.tf
<li>Updated <code>csi_driver_version</code> to <code>v1.31.0-eksbuild.1</code><br> <li> Updated <code>coredns_version</code> to <code>v1.10.1-eksbuild.11</code><br> <li> Updated <code>kube_proxy_version</code> to <code>v1.28.8-eksbuild.5</code><br> <li> Updated <code>ami_image_id</code> for node pools<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster/pull/123/files#diff-4e2a69ff168330fbfa3acdcf8839f73d73a50a9b10bcd1bf0567166bc37b91e3">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Update default versions for EKS components and AMI image ID</code></dd></summary>
<hr>

variables.tf
<li>Updated default <code>csi_driver_version</code> to <code>v1.31.0-eksbuild.1</code><br> <li> Updated default <code>coredns_version</code> to <code>v1.10.1-eksbuild.11</code><br> <li> Updated default <code>kube_proxy_version</code> to <code>v1.28.8-eksbuild.5</code><br> <li> Updated default <code>ami_image_id</code> for node pools<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster/pull/123/files#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288e">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README with new AMI image ID and component versions</code></dd></summary>
<hr>

README.md
<li>Updated <code>ami_image_id</code> for node pools in example configuration<br> <li> Updated documented default versions for <code>csi_driver_version</code>, <br><code>coredns_version</code>, and <code>kube_proxy_version</code><br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster/pull/123/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>.header.md</strong><dd><code>Update documentation header with new AMI image ID</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/.header.md
- Updated `ami_image_id` for node pools in example configuration



</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster/pull/123/files#diff-1a920578bc3e05f584ae3733aa0a891fa9af5fbae8afe498215e2df849598eb4">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

