### PR TITLE
chore: update versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ module "captain" {
   iam_role_to_assume = "arn:aws:iam::1234567890:role/glueops-captain-role"
   source             = "git::https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster.git"
   eks_version        = "1.28"
-  csi_driver_version = "v1.30.0-eksbuild.1"
-  coredns_version    = "v1.10.1-eksbuild.7"
-  kube_proxy_version = "v1.28.6-eksbuild.2"
+  csi_driver_version = "v1.31.0-eksbuild.1"
+  coredns_version    = "v1.10.1-eksbuild.11"
+  kube_proxy_version = "v1.28.8-eksbuild.5"
   vpc_cidr_block     = "10.65.0.0/26"
   region             = "us-west-2"
   availability_zones = ["us-west-2a", "us-west-2b"]

--- a/docs/.header.md
+++ b/docs/.header.md
@@ -17,9 +17,9 @@ module "captain" {
   iam_role_to_assume = "arn:aws:iam::1234567890:role/glueops-captain-role"
   source             = "git::https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster.git"
   eks_version        = "1.28"
-  csi_driver_version = "v1.30.0-eksbuild.1"
-  coredns_version    = "v1.10.1-eksbuild.7"
-  kube_proxy_version = "v1.28.6-eksbuild.2"
+  csi_driver_version = "v1.31.0-eksbuild.1"
+  coredns_version    = "v1.10.1-eksbuild.11"
+  kube_proxy_version = "v1.28.8-eksbuild.5"
   vpc_cidr_block     = "10.65.0.0/26"
   region             = "us-west-2"
   availability_zones = ["us-west-2a", "us-west-2b"]


### PR DESCRIPTION
### **PR Type**
documentation, enhancement


___

### **Description**
- Updated the `csi_driver_version` to `v1.31.0-eksbuild.1` in the documentation.
- Updated the `coredns_version` to `v1.10.1-eksbuild.11` in the documentation.
- Updated the `kube_proxy_version` to `v1.28.8-eksbuild.5` in the documentation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.header.md</strong><dd><code>Update Kubernetes component versions in documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/.header.md
<li>Updated <code>csi_driver_version</code> from <code>v1.30.0-eksbuild.1</code> to <br><code>v1.31.0-eksbuild.1</code><br> <li> Updated <code>coredns_version</code> from <code>v1.10.1-eksbuild.7</code> to <code>v1.10.1-eksbuild.11</code><br> <li> Updated <code>kube_proxy_version</code> from <code>v1.28.6-eksbuild.2</code> to <br><code>v1.28.8-eksbuild.5</code><br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster/pull/127/files#diff-1a920578bc3e05f584ae3733aa0a891fa9af5fbae8afe498215e2df849598eb4">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

