### PR TITLE
fix: ami release name and update aws nuke

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ module "captain" {
   availability_zones = ["us-west-2a", "us-west-2b"]
   node_pools = [
 #    {
-#      "ami_image_id" : "ami-0a62f3a52fa691069",
+#      "ami_release_version" : "1.28.11-20240807",
+#      "ami_type" : "AL2_x86_64",
 #      "instance_type" : "t3a.large",
 #      "name" : "glueops-platform-node-pool-1",
 #      "node_count" : 4,
@@ -46,7 +47,8 @@ module "captain" {
 #      ]
 #    },
 #    {
-#      "ami_image_id" : "ami-0a62f3a52fa691069",
+#      "ami_release_version" : "1.28.11-20240807",
+#      "ami_type" : "AL2_x86_64",
 #      "instance_type" : "t3a.small",
 #      "name" : "glueops-platform-node-pool-argocd-app-controller-1",
 #      "node_count" : 2,
@@ -66,7 +68,8 @@ module "captain" {
 #      ]
 #    },
 #    {
-#      "ami_image_id" : "ami-0a62f3a52fa691069",
+#      "ami_release_version" : "1.28.11-20240807",
+#      "ami_type" : "AL2_x86_64",
 #      "instance_type" : "t3a.medium",
 #      "name" : "clusterwide-node-pool-1",
 #      "node_count" : 2,

--- a/docs/.header.md
+++ b/docs/.header.md
@@ -25,7 +25,8 @@ module "captain" {
   availability_zones = ["us-west-2a", "us-west-2b"]
   node_pools = [
 #    {
-#      "ami_image_id" : "ami-0a62f3a52fa691069",
+#      "ami_release_version" : "1.28.11-20240807",
+#      "ami_type" : "AL2_x86_64",
 #      "instance_type" : "t3a.large",
 #      "name" : "glueops-platform-node-pool-1",
 #      "node_count" : 4,
@@ -45,7 +46,8 @@ module "captain" {
 #      ]
 #    },
 #    {
-#      "ami_image_id" : "ami-0a62f3a52fa691069",
+#      "ami_release_version" : "1.28.11-20240807",
+#      "ami_type" : "AL2_x86_64",
 #      "instance_type" : "t3a.small",
 #      "name" : "glueops-platform-node-pool-argocd-app-controller-1",
 #      "node_count" : 2,
@@ -65,7 +67,8 @@ module "captain" {
 #      ]
 #    },
 #    {
-#      "ami_image_id" : "ami-0a62f3a52fa691069",
+#      "ami_release_version" : "1.28.11-20240807",
+#      "ami_type" : "AL2_x86_64",
 #      "instance_type" : "t3a.medium",
 #      "name" : "clusterwide-node-pool-1",
 #      "node_count" : 2,

--- a/tests/destroy-aws.sh
+++ b/tests/destroy-aws.sh
@@ -2,5 +2,5 @@
 
 # reference: https://github.com/GlueOps/scripts-teardown-aws-amazon-web-services
 echo "Preform an AWS Cleanup with AWS Nuke"
-wget https://github.com/rebuy-de/aws-nuke/releases/download/v2.24.2/aws-nuke-v2.24.2-linux-amd64.tar.gz && tar -xvf aws-nuke-v2.24.2-linux-amd64.tar.gz && rm aws-nuke-v2.24.2-linux-amd64.tar.gz && mv aws-nuke-v2.24.2-linux-amd64 aws-nuke
+wget https://github.com/rebuy-de/aws-nuke/releases/download/v2.25.0/aws-nuke-v2.25.0-linux-amd64.tar.gz && tar -xvf aws-nuke-v2.25.0-linux-amd64.tar.gz && rm aws-nuke-v2.25.0-linux-amd64.tar.gz && mv aws-nuke-v2.25.0-linux-amd64 aws-nuke
 ./aws-nuke -c aws-nuke.yaml --no-dry-run --force

--- a/tests/main.tf
+++ b/tests/main.tf
@@ -10,7 +10,7 @@ module "captain" {
   availability_zones = ["us-west-2a", "us-west-2b"]
   node_pools = [
 #    {
-#      "ami_release_version" : "1.29.6-20240729",
+#      "ami_release_version" : "1.28.11-20240807",
 #      "ami_type" : "AL2_x86_64",
 #      "instance_type" : "t3a.large",
 #      "name" : "glueops-platform-node-pool-1",
@@ -31,7 +31,7 @@ module "captain" {
 #      ]
 #    },
 #    {
-#      "ami_release_version" : "1.29.6-20240729",
+#      "ami_release_version" : "1.28.11-20240807",
 #      "ami_type" : "AL2_x86_64",
 #      "instance_type" : "t3a.small",
 #      "name" : "glueops-platform-node-pool-argocd-app-controller-1",
@@ -52,7 +52,7 @@ module "captain" {
 #      ]
 #    },
 #    {
-#      "ami_release_version" : "1.29.6-20240729",
+#      "ami_release_version" : "1.28.11-20240807",
 #      "ami_type" : "AL2_x86_64",
 #      "instance_type" : "t3a.medium",
 #      "name" : "clusterwide-node-pool-1",


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Updated AMI release version in the Terraform configuration to `1.28.11-20240807`.
- Upgraded AWS Nuke version in the cleanup script to `v2.25.0`.
- Modified documentation to replace `ami_image_id` with `ami_release_version` and `ami_type` for consistency.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Update AMI release version in Terraform configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/main.tf

<li>Updated <code>ami_release_version</code> for multiple node pools.<br> <li> Changed version from <code>1.29.6-20240729</code> to <code>1.28.11-20240807</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster/pull/140/files#diff-4e2a69ff168330fbfa3acdcf8839f73d73a50a9b10bcd1bf0567166bc37b91e3">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>destroy-aws.sh</strong><dd><code>Upgrade AWS Nuke version in cleanup script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/destroy-aws.sh

- Updated AWS Nuke version from `v2.24.2` to `v2.25.0`.



</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster/pull/140/files#diff-7ac0135e6183286824be8dca412c6b4822dcbb30d40b8154193ad7fba80094af">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.header.md</strong><dd><code>Update AMI details in documentation header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/.header.md

<li>Replaced <code>ami_image_id</code> with <code>ami_release_version</code> and <code>ami_type</code>.<br> <li> Updated AMI details for documentation consistency.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster/pull/140/files#diff-1a920578bc3e05f584ae3733aa0a891fa9af5fbae8afe498215e2df849598eb4">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

