### PR TITLE
feat: allowing manual runs of regression on demand

### DIFF
--- a/.github/workflows/aws-cloud-regression-suite.yml
+++ b/.github/workflows/aws-cloud-regression-suite.yml
@@ -11,6 +11,7 @@ jobs:
     concurrency:
       group: aws_regression_suite
       cancel-in-progress: true
+    workflow_dispatch:
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Added `workflow_dispatch` to the GitHub Actions workflow configuration to allow manual execution of the AWS cloud regression suite.
- This change enables developers to trigger regression tests on demand, improving flexibility in testing.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aws-cloud-regression-suite.yml</strong><dd><code>Enable manual triggering of AWS regression suite workflow</code></dd></summary>
<hr>

.github/workflows/aws-cloud-regression-suite.yml

<li>Added <code>workflow_dispatch</code> to allow manual triggering of the workflow.<br> <li> Ensures that the regression suite can be run on demand.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster/pull/166/files#diff-e490df27c497a7f68f533406a9c586c97dc63277a893961dea02841a6e98ecb5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information