### PR TITLE
fix: aws-cloud-regression-suite.yml

### DIFF
--- a/.github/workflows/aws-cloud-regression-suite.yml
+++ b/.github/workflows/aws-cloud-regression-suite.yml
@@ -3,6 +3,7 @@ name: AWS Regression Suite
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 jobs:
   run_docker:
@@ -11,7 +12,6 @@ jobs:
     concurrency:
       group: aws_regression_suite
       cancel-in-progress: true
-  workflow_dispatch:
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Added a `workflow_dispatch` trigger to the AWS Regression Suite workflow to enable manual execution of the workflow.
- Corrected the placement of the `workflow_dispatch` trigger by removing it from under the `concurrency` section.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aws-cloud-regression-suite.yml</strong><dd><code>Add manual trigger and fix workflow configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/aws-cloud-regression-suite.yml

<li>Added <code>workflow_dispatch</code> trigger to allow manual workflow runs.<br> <li> Removed misplaced <code>workflow_dispatch</code> under <code>concurrency</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster/pull/174/files#diff-e490df27c497a7f68f533406a9c586c97dc63277a893961dea02841a6e98ecb5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information