### PR TITLE
fix: CSI driver so that we deploy a defaultStorageClass

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -18,6 +18,10 @@ echo "::endgroup::"
 echo "::group::Configuring Kubernetes"
 echo "Authenticate with Kubernetes"
 aws eks update-kubeconfig --region us-west-2 --name captain-cluster --role-arn arn:aws:iam::761182885829:role/glueops-captain-role
+
+echo "Show current storageclasses (immediately after bootstrap)"
+kubectl get storageclass -A
+
 echo "Delete AWS CNI"
 kubectl delete daemonset -n kube-system aws-node
 echo "Install Calico CNI"
@@ -34,6 +38,9 @@ echo "Get nodes and pods from kubernetes"
 kubectl get nodes
 kubectl get pods -A -o=wide
 echo "::endgroup::"
+
+echo "Show current storageclasses (before test suite)"
+kubectl get storageclass -A
 
 echo "==> Start Test Suite"
 ./k8s-test.sh

--- a/variables.tf
+++ b/variables.tf
@@ -24,11 +24,17 @@ variable "kube_proxy_version" {
 
 locals {
 
-  csi_addon_node_tolerations = jsonencode({
+  map_csi_addon_node_tolerations = {
     controller = local.nodeselector_and_pod_tolerations
+  }
+  
+  map_csi_default_storage = {
+    defaultStorageClass = {
+      enabled = true
+    }
+  }
 
-  })
-
+  csi_addon_node_tolerations = jsonencode(merge(local.map_csi_addon_node_tolerations, local.map_csi_default_storage))
 
   nodeselector_and_pod_tolerations = {
     nodeSelector = {


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Introduced a new configuration for deploying a default storage class in the CSI driver.
- Merged existing node tolerations with the new default storage class settings to enhance the CSI configuration.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Add default storage class configuration for CSI driver</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

variables.tf

<li>Added a new local variable <code>map_csi_default_storage</code> to define default <br>storage class settings.<br> <li> Merged <code>map_csi_addon_node_tolerations</code> with <code>map_csi_default_storage</code> for <br>CSI configuration.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster/pull/196/files#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288e">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information