### PR TITLE
chore: bumps kubernetes versions for 1.31

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,26 +17,26 @@ For more details see: https://github.com/GlueOps/terraform-module-cloud-aws-kube
 module "captain" {
   iam_role_to_assume = "arn:aws:iam::1234567890:role/glueops-captain-role"
   source             = "git::https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster.git"
-  eks_version        = "1.30"
+  eks_version        = "1.31"
   # kubernetesVersion and addonName provided
-  # renovate: eksAddonsFilter={"kubernetesVersion":"1.30","addonName":"aws-ebs-csi-driver"}
+  # renovate: eksAddonsFilter={"kubernetesVersion":"1.31","addonName":"aws-ebs-csi-driver"}
   csi_driver_version = "v1.44.0-eksbuild.1"
 
   # kubernetesVersion and addonName provided
-  # renovate: eksAddonsFilter={"kubernetesVersion":"1.30","addonName":"coredns"}
+  # renovate: eksAddonsFilter={"kubernetesVersion":"1.31","addonName":"coredns"}
   coredns_version    = "v1.11.4-eksbuild.14"
 
   # kubernetesVersion and addonName provided
-  # renovate: eksAddonsFilter={"kubernetesVersion":"1.30","addonName":"kube-proxy"}
-  kube_proxy_version = "v1.30.11-eksbuild.5"
+  # renovate: eksAddonsFilter={"kubernetesVersion":"1.31","addonName":"kube-proxy"}
+  kube_proxy_version = "v1.31.9-eksbuild.2"
   vpc_cidr_block     = "10.65.0.0/26"
   region             = "us-west-2"
   availability_zones = ["us-west-2a", "us-west-2b"]
   private_subnets_enabled = false
   node_pools = [
 #    {
-#      "kubernetes_version" : "1.30",
-#      "ami_release_version" : "1.30.11-20250610",
+#      "kubernetes_version" : "1.31",
+#      "ami_release_version" : "1.31.7-20250620",
 #      "ami_type" : "AL2_x86_64",
 #      "instance_type" : "t3a.large",
 #      "name" : "glueops-platform-node-pool-1",
@@ -57,8 +57,8 @@ module "captain" {
 #      ]
 #    },
 #    {
-#      "kubernetes_version" : "1.30",
-#      "ami_release_version" : "1.30.11-20250610",
+#      "kubernetes_version" : "1.31",
+#      "ami_release_version" : "1.31.7-20250620",
 #      "ami_type" : "AL2_x86_64",
 #      "instance_type" : "t3a.small",
 #      "name" : "glueops-platform-node-pool-argocd-app-controller-1",
@@ -79,8 +79,8 @@ module "captain" {
 #      ]
 #    },
 #    {
-#      "kubernetes_version" : "1.30",
-#      "ami_release_version" : "1.30.11-20250610",
+#      "kubernetes_version" : "1.31",
+#      "ami_release_version" : "1.31.7-20250620",
 #      "ami_type" : "AL2_x86_64",
 #      "instance_type" : "t3a.medium",
 #      "name" : "clusterwide-node-pool-1",
@@ -206,10 +206,10 @@ No requirements.
 | <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | The availability zones to deploy into | `list(string)` | <pre>[<br/>  "us-west-2a",<br/>  "us-west-2b",<br/>  "us-west-2c"<br/>]</pre> | no |
 | <a name="input_coredns_version"></a> [coredns\_version](#input\_coredns\_version) | You should grab the appropriate version number from: https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html | `string` | `"v1.11.4-eksbuild.14"` | no |
 | <a name="input_csi_driver_version"></a> [csi\_driver\_version](#input\_csi\_driver\_version) | You should grab the appropriate version number from: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG.md | `string` | `"v1.44.0-eksbuild.1"` | no |
-| <a name="input_eks_version"></a> [eks\_version](#input\_eks\_version) | The version of EKS to deploy | `string` | `"1.30"` | no |
+| <a name="input_eks_version"></a> [eks\_version](#input\_eks\_version) | The version of EKS to deploy | `string` | `"1.31"` | no |
 | <a name="input_iam_role_to_assume"></a> [iam\_role\_to\_assume](#input\_iam\_role\_to\_assume) | The full ARN of the IAM role to assume | `string` | n/a | yes |
-| <a name="input_kube_proxy_version"></a> [kube\_proxy\_version](#input\_kube\_proxy\_version) | You should grab the appropriate version number from: https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html | `string` | `"v1.30.11-eksbuild.5"` | no |
-| <a name="input_node_pools"></a> [node\_pools](#input\_node\_pools) | node pool configurations:<br/>  - name (string): Name of the node pool. MUST BE UNIQUE! Recommended to use YYYYMMDD in the name<br/>  - node\_count (number): number of nodes to create in the node pool.<br/>  - instance\_type (string): Instance type to use for the nodes. ref: https://instances.vantage.sh/<br/>  - kubernetes\_version (string): Generally this is the same version as the EKS cluster. But if doing a node pool upgrade this may be a different version.<br/>  - ami\_release\_version (string): AMI Release version to use for EKS worker nodes. ref: https://github.com/awslabs/amazon-eks-ami/releases<br/>  - ami\_type (string): e.g. AMD64 or ARM<br/>  - spot (bool): Enable spot instances for the nodes. DO NOT ENABLE IN PROD!<br/>  - disk\_size\_gb (number): Disk size in GB for the nodes.<br/>  - max\_pods (number): max pods that can be scheduled per node.<br/>  - ssh\_key\_pair\_names (list(string)): List of SSH key pair names to associate with the nodes. ref: https://us-west-2.console.aws.amazon.com/ec2/home?region=us-west-2#KeyPairs:<br/>  - kubernetes\_labels (map(string)): Map of labels to apply to the nodes. ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/<br/>  - kubernetes\_taints (list(object)): List of taints to apply to the nodes. ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ | <pre>list(object({<br/>    name                = string<br/>    node_count          = number<br/>    instance_type       = string<br/>    kubernetes_version  = string<br/>    ami_release_version = string<br/>    ami_type            = string<br/>    spot                = bool<br/>    disk_size_gb        = number<br/>    max_pods            = number<br/>    ssh_key_pair_names  = list(string)<br/>    kubernetes_labels   = map(string)<br/>    kubernetes_taints = list(object({<br/>      key    = string<br/>      value  = string<br/>      effect = string<br/>    }))<br/><br/>  }))</pre> | <pre>[<br/>  {<br/>    "ami_release_version": "1.30.11-20250610",<br/>    "ami_type": "AL2_x86_64",<br/>    "disk_size_gb": 20,<br/>    "instance_type": "t3a.large",<br/>    "kubernetes_labels": {},<br/>    "kubernetes_taints": [],<br/>    "kubernetes_version": "1.30",<br/>    "max_pods": 110,<br/>    "name": "default-pool",<br/>    "node_count": 1,<br/>    "spot": false,<br/>    "ssh_key_pair_names": []<br/>  }<br/>]</pre> | no |
+| <a name="input_kube_proxy_version"></a> [kube\_proxy\_version](#input\_kube\_proxy\_version) | You should grab the appropriate version number from: https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html | `string` | `"v1.31.9-eksbuild.2"` | no |
+| <a name="input_node_pools"></a> [node\_pools](#input\_node\_pools) | node pool configurations:<br/>  - name (string): Name of the node pool. MUST BE UNIQUE! Recommended to use YYYYMMDD in the name<br/>  - node\_count (number): number of nodes to create in the node pool.<br/>  - instance\_type (string): Instance type to use for the nodes. ref: https://instances.vantage.sh/<br/>  - kubernetes\_version (string): Generally this is the same version as the EKS cluster. But if doing a node pool upgrade this may be a different version.<br/>  - ami\_release\_version (string): AMI Release version to use for EKS worker nodes. ref: https://github.com/awslabs/amazon-eks-ami/releases<br/>  - ami\_type (string): e.g. AMD64 or ARM<br/>  - spot (bool): Enable spot instances for the nodes. DO NOT ENABLE IN PROD!<br/>  - disk\_size\_gb (number): Disk size in GB for the nodes.<br/>  - max\_pods (number): max pods that can be scheduled per node.<br/>  - ssh\_key\_pair\_names (list(string)): List of SSH key pair names to associate with the nodes. ref: https://us-west-2.console.aws.amazon.com/ec2/home?region=us-west-2#KeyPairs:<br/>  - kubernetes\_labels (map(string)): Map of labels to apply to the nodes. ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/<br/>  - kubernetes\_taints (list(object)): List of taints to apply to the nodes. ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ | <pre>list(object({<br/>    name                = string<br/>    node_count          = number<br/>    instance_type       = string<br/>    kubernetes_version  = string<br/>    ami_release_version = string<br/>    ami_type            = string<br/>    spot                = bool<br/>    disk_size_gb        = number<br/>    max_pods            = number<br/>    ssh_key_pair_names  = list(string)<br/>    kubernetes_labels   = map(string)<br/>    kubernetes_taints = list(object({<br/>      key    = string<br/>      value  = string<br/>      effect = string<br/>    }))<br/><br/>  }))</pre> | <pre>[<br/>  {<br/>    "ami_release_version": "1.31.7-20250620",<br/>    "ami_type": "AL2_x86_64",<br/>    "disk_size_gb": 20,<br/>    "instance_type": "t3a.large",<br/>    "kubernetes_labels": {},<br/>    "kubernetes_taints": [],<br/>    "kubernetes_version": "1.31",<br/>    "max_pods": 110,<br/>    "name": "default-pool",<br/>    "node_count": 1,<br/>    "spot": false,<br/>    "ssh_key_pair_names": []<br/>  }<br/>]</pre> | no |
 | <a name="input_peering_configs"></a> [peering\_configs](#input\_peering\_configs) | A list of maps containing VPC peering configuration details | <pre>list(object({<br/>    vpc_peering_connection_id = string<br/>    destination_cidr_block    = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_private_subnets_enabled"></a> [private\_subnets\_enabled](#input\_private\_subnets\_enabled) | enable private subnets | `bool` | `false` | no |
 | <a name="input_region"></a> [region](#input\_region) | The AWS region to deploy into | `string` | n/a | yes |

--- a/docs/.header.md
+++ b/docs/.header.md
@@ -17,26 +17,26 @@ For more details see: https://github.com/GlueOps/terraform-module-cloud-aws-kube
 module "captain" {
   iam_role_to_assume = "arn:aws:iam::1234567890:role/glueops-captain-role"
   source             = "git::https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster.git"
-  eks_version        = "1.30"
+  eks_version        = "1.31"
   # kubernetesVersion and addonName provided
-  # renovate: eksAddonsFilter={"kubernetesVersion":"1.30","addonName":"aws-ebs-csi-driver"}
+  # renovate: eksAddonsFilter={"kubernetesVersion":"1.31","addonName":"aws-ebs-csi-driver"}
   csi_driver_version = "v1.44.0-eksbuild.1"
 
   # kubernetesVersion and addonName provided
-  # renovate: eksAddonsFilter={"kubernetesVersion":"1.30","addonName":"coredns"}
+  # renovate: eksAddonsFilter={"kubernetesVersion":"1.31","addonName":"coredns"}
   coredns_version    = "v1.11.4-eksbuild.14"
 
   # kubernetesVersion and addonName provided
-  # renovate: eksAddonsFilter={"kubernetesVersion":"1.30","addonName":"kube-proxy"}
-  kube_proxy_version = "v1.30.11-eksbuild.5"
+  # renovate: eksAddonsFilter={"kubernetesVersion":"1.31","addonName":"kube-proxy"}
+  kube_proxy_version = "v1.31.9-eksbuild.2"
   vpc_cidr_block     = "10.65.0.0/26"
   region             = "us-west-2"
   availability_zones = ["us-west-2a", "us-west-2b"]
   private_subnets_enabled = false
   node_pools = [
 #    {
-#      "kubernetes_version" : "1.30",
-#      "ami_release_version" : "1.30.11-20250610",
+#      "kubernetes_version" : "1.31",
+#      "ami_release_version" : "1.31.7-20250620",
 #      "ami_type" : "AL2_x86_64",
 #      "instance_type" : "t3a.large",
 #      "name" : "glueops-platform-node-pool-1",
@@ -57,8 +57,8 @@ module "captain" {
 #      ]
 #    },
 #    {
-#      "kubernetes_version" : "1.30",
-#      "ami_release_version" : "1.30.11-20250610",
+#      "kubernetes_version" : "1.31",
+#      "ami_release_version" : "1.31.7-20250620",
 #      "ami_type" : "AL2_x86_64",
 #      "instance_type" : "t3a.small",
 #      "name" : "glueops-platform-node-pool-argocd-app-controller-1",
@@ -79,8 +79,8 @@ module "captain" {
 #      ]
 #    },
 #    {
-#      "kubernetes_version" : "1.30",
-#      "ami_release_version" : "1.30.11-20250610",
+#      "kubernetes_version" : "1.31",
+#      "ami_release_version" : "1.31.7-20250620",
 #      "ami_type" : "AL2_x86_64",
 #      "instance_type" : "t3a.medium",
 #      "name" : "clusterwide-node-pool-1",

--- a/glueops-tests/main.tf
+++ b/glueops-tests/main.tf
@@ -1,18 +1,18 @@
 module "captain" {
   iam_role_to_assume = "arn:aws:iam::761182885829:role/glueops-captain-role"
   source             = "../"
-  eks_version        = "1.30"
+  eks_version        = "1.31"
   # kubernetesVersion and addonName provided
-  # renovate: eksAddonsFilter={"kubernetesVersion":"1.30","addonName":"aws-ebs-csi-driver"}
+  # renovate: eksAddonsFilter={"kubernetesVersion":"1.31","addonName":"aws-ebs-csi-driver"}
   csi_driver_version = "v1.44.0-eksbuild.1"
 
   # kubernetesVersion and addonName provided
-  # renovate: eksAddonsFilter={"kubernetesVersion":"1.30","addonName":"coredns"}
+  # renovate: eksAddonsFilter={"kubernetesVersion":"1.31","addonName":"coredns"}
   coredns_version = "v1.11.4-eksbuild.14"
 
   # kubernetesVersion and addonName provided
-  # renovate: eksAddonsFilter={"kubernetesVersion":"1.30","addonName":"kube-proxy"}
-  kube_proxy_version = "v1.30.11-eksbuild.5"
+  # renovate: eksAddonsFilter={"kubernetesVersion":"1.31","addonName":"kube-proxy"}
+  kube_proxy_version = "v1.31.9-eksbuild.2"
 
   vpc_cidr_block          = "10.65.0.0/26"
   region                  = "us-west-2"
@@ -20,8 +20,8 @@ module "captain" {
   private_subnets_enabled = false
   node_pools = [
     #    {
-    #      "kubernetes_version" : "1.30",
-    #      "ami_release_version" : "1.30.11-20250610",
+    #      "kubernetes_version" : "1.31",
+    #      "ami_release_version" : "1.31.7-20250620",
     #      "ami_type" : "AL2_x86_64",
     #      "instance_type" : "t3a.large",
     #      "name" : "glueops-platform-node-pool-1",
@@ -42,8 +42,8 @@ module "captain" {
     #      ]
     #    },
     #    {
-    #      "kubernetes_version" : "1.30",
-    #      "ami_release_version" : "1.30.11-20250610",
+    #      "kubernetes_version" : "1.31",
+    #      "ami_release_version" : "1.31.7-20250620",
     #      "ami_type" : "AL2_x86_64",
     #      "instance_type" : "t3a.small",
     #      "name" : "glueops-platform-node-pool-argocd-app-controller-1",
@@ -64,8 +64,8 @@ module "captain" {
     #      ]
     #    },
     #    {
-    #      "kubernetes_version" : "1.30",
-    #      "ami_release_version" : "1.30.11-20250610",
+    #      "kubernetes_version" : "1.31",
+    #      "ami_release_version" : "1.31.7-20250620",
     #      "ami_type" : "AL2_x86_64",
     #      "instance_type" : "t3a.medium",
     #      "name" : "clusterwide-node-pool-1",

--- a/variables.tf
+++ b/variables.tf
@@ -6,7 +6,7 @@ variable "region" {
 variable "csi_driver_version" {
   type = string
   # kubernetesVersion and addonName provided
-  # renovate: eksAddonsFilter={"kubernetesVersion":"1.30","addonName":"aws-ebs-csi-driver"}
+  # renovate: eksAddonsFilter={"kubernetesVersion":"1.31","addonName":"aws-ebs-csi-driver"}
   default     = "v1.44.0-eksbuild.1"
   description = "You should grab the appropriate version number from: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG.md"
 }
@@ -14,7 +14,7 @@ variable "csi_driver_version" {
 variable "coredns_version" {
   type = string
   # kubernetesVersion and addonName provided
-  # renovate: eksAddonsFilter={"kubernetesVersion":"1.30","addonName":"coredns"}
+  # renovate: eksAddonsFilter={"kubernetesVersion":"1.31","addonName":"coredns"}
   default     = "v1.11.4-eksbuild.14"
   description = "You should grab the appropriate version number from: https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html"
 }
@@ -22,8 +22,8 @@ variable "coredns_version" {
 variable "kube_proxy_version" {
   type = string
   # kubernetesVersion and addonName provided
-  # renovate: eksAddonsFilter={"kubernetesVersion":"1.30","addonName":"kube-proxy"}
-  default     = "v1.30.11-eksbuild.5"
+  # renovate: eksAddonsFilter={"kubernetesVersion":"1.31","addonName":"kube-proxy"}
+  default     = "v1.31.9-eksbuild.2"
   description = "You should grab the appropriate version number from: https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html"
 }
 
@@ -83,7 +83,7 @@ variable "private_subnets_enabled" {
 variable "eks_version" {
   type        = string
   description = "The version of EKS to deploy"
-  default     = "1.30"
+  default     = "1.31"
 }
 
 variable "node_pools" {
@@ -110,8 +110,8 @@ variable "node_pools" {
     name                = "default-pool"
     node_count          = 1
     instance_type       = "t3a.large"
-    ami_release_version = "1.30.11-20250610"
-    kubernetes_version  = "1.30"
+    ami_release_version = "1.31.7-20250620"
+    kubernetes_version  = "1.31"
     ami_type            = "AL2_x86_64"
     spot                = false
     disk_size_gb        = 20


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Upgrade EKS cluster version from 1.30 to 1.31

- Update kube-proxy version to v1.31.9-eksbuild.2

- Update AMI release versions for node pools

- Update renovate filter configurations for Kubernetes 1.31


___

### **Changes diagram**

```mermaid
flowchart LR
  A["EKS 1.30"] --> B["EKS 1.31"]
  C["kube-proxy v1.30.11"] --> D["kube-proxy v1.31.9"]
  E["AMI 1.30.11-20250610"] --> F["AMI 1.31.7-20250620"]
  G["Renovate filters"] --> H["Updated for 1.31"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Update test configuration for Kubernetes 1.31</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

glueops-tests/main.tf

<li>Update <code>eks_version</code> from "1.30" to "1.31"<br> <li> Update <code>kube_proxy_version</code> to "v1.31.9-eksbuild.2"<br> <li> Update renovate filter comments for Kubernetes 1.31<br> <li> Update commented node pool configurations with new versions


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster/pull/258/files#diff-b9b7b428f9e731cecb2817beb5e1f18961ef2d057e69298993f6fc6bb749de4e">+11/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Update variable defaults for Kubernetes 1.31</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

variables.tf

<li>Update default <code>eks_version</code> from "1.30" to "1.31"<br> <li> Update default <code>kube_proxy_version</code> to "v1.31.9-eksbuild.2"<br> <li> Update renovate filter comments for all addons<br> <li> Update default node pool AMI and Kubernetes versions


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster/pull/258/files#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288e">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update documentation for Kubernetes 1.31</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Update example configuration with Kubernetes 1.31<br> <li> Update kube-proxy version in documentation table<br> <li> Update node pool examples with new AMI versions<br> <li> Update input variable documentation


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster/pull/258/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+14/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>.header.md</strong><dd><code>Update header documentation for Kubernetes 1.31</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/.header.md

<li>Update example module configuration for Kubernetes 1.31<br> <li> Update kube-proxy version to v1.31.9-eksbuild.2<br> <li> Update renovate filter comments<br> <li> Update node pool examples with new versions


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster/pull/258/files#diff-1a920578bc3e05f584ae3733aa0a891fa9af5fbae8afe498215e2df849598eb4">+11/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>