### PR TITLE
feat: replacing the old ami_type with: AL2023_x86_64_STANDARD

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ module "captain" {
 #    {
 #      "kubernetes_version" : "1.31",
 #      "ami_release_version" : "1.31.7-20250620",
-#      "ami_type" : "AL2_x86_64",
+#      "ami_type" : "AL2023_x86_64_STANDARD",
 #      "instance_type" : "t3a.large",
 #      "name" : "glueops-platform-node-pool-1",
 #      "node_count" : 4,
@@ -59,7 +59,7 @@ module "captain" {
 #    {
 #      "kubernetes_version" : "1.31",
 #      "ami_release_version" : "1.31.7-20250620",
-#      "ami_type" : "AL2_x86_64",
+#      "ami_type" : "AL2023_x86_64_STANDARD",
 #      "instance_type" : "t3a.small",
 #      "name" : "glueops-platform-node-pool-argocd-app-controller-1",
 #      "node_count" : 2,
@@ -81,7 +81,7 @@ module "captain" {
 #    {
 #      "kubernetes_version" : "1.31",
 #      "ami_release_version" : "1.31.7-20250620",
-#      "ami_type" : "AL2_x86_64",
+#      "ami_type" : "AL2023_x86_64_STANDARD",
 #      "instance_type" : "t3a.medium",
 #      "name" : "clusterwide-node-pool-1",
 #      "node_count" : 2,
@@ -209,7 +209,7 @@ No requirements.
 | <a name="input_eks_version"></a> [eks\_version](#input\_eks\_version) | The version of EKS to deploy | `string` | `"1.31"` | no |
 | <a name="input_iam_role_to_assume"></a> [iam\_role\_to\_assume](#input\_iam\_role\_to\_assume) | The full ARN of the IAM role to assume | `string` | n/a | yes |
 | <a name="input_kube_proxy_version"></a> [kube\_proxy\_version](#input\_kube\_proxy\_version) | You should grab the appropriate version number from: https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html | `string` | `"v1.31.9-eksbuild.2"` | no |
-| <a name="input_node_pools"></a> [node\_pools](#input\_node\_pools) | node pool configurations:<br/>  - name (string): Name of the node pool. MUST BE UNIQUE! Recommended to use YYYYMMDD in the name<br/>  - node\_count (number): number of nodes to create in the node pool.<br/>  - instance\_type (string): Instance type to use for the nodes. ref: https://instances.vantage.sh/<br/>  - kubernetes\_version (string): Generally this is the same version as the EKS cluster. But if doing a node pool upgrade this may be a different version.<br/>  - ami\_release\_version (string): AMI Release version to use for EKS worker nodes. ref: https://github.com/awslabs/amazon-eks-ami/releases<br/>  - ami\_type (string): e.g. AMD64 or ARM<br/>  - spot (bool): Enable spot instances for the nodes. DO NOT ENABLE IN PROD!<br/>  - disk\_size\_gb (number): Disk size in GB for the nodes.<br/>  - max\_pods (number): max pods that can be scheduled per node.<br/>  - ssh\_key\_pair\_names (list(string)): List of SSH key pair names to associate with the nodes. ref: https://us-west-2.console.aws.amazon.com/ec2/home?region=us-west-2#KeyPairs:<br/>  - kubernetes\_labels (map(string)): Map of labels to apply to the nodes. ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/<br/>  - kubernetes\_taints (list(object)): List of taints to apply to the nodes. ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ | <pre>list(object({<br/>    name                = string<br/>    node_count          = number<br/>    instance_type       = string<br/>    kubernetes_version  = string<br/>    ami_release_version = string<br/>    ami_type            = string<br/>    spot                = bool<br/>    disk_size_gb        = number<br/>    max_pods            = number<br/>    ssh_key_pair_names  = list(string)<br/>    kubernetes_labels   = map(string)<br/>    kubernetes_taints = list(object({<br/>      key    = string<br/>      value  = string<br/>      effect = string<br/>    }))<br/><br/>  }))</pre> | <pre>[<br/>  {<br/>    "ami_release_version": "1.31.7-20250620",<br/>    "ami_type": "AL2_x86_64",<br/>    "disk_size_gb": 20,<br/>    "instance_type": "t3a.large",<br/>    "kubernetes_labels": {},<br/>    "kubernetes_taints": [],<br/>    "kubernetes_version": "1.31",<br/>    "max_pods": 110,<br/>    "name": "default-pool",<br/>    "node_count": 1,<br/>    "spot": false,<br/>    "ssh_key_pair_names": []<br/>  }<br/>]</pre> | no |
+| <a name="input_node_pools"></a> [node\_pools](#input\_node\_pools) | node pool configurations:<br/>  - name (string): Name of the node pool. MUST BE UNIQUE! Recommended to use YYYYMMDD in the name<br/>  - node\_count (number): number of nodes to create in the node pool.<br/>  - instance\_type (string): Instance type to use for the nodes. ref: https://instances.vantage.sh/<br/>  - kubernetes\_version (string): Generally this is the same version as the EKS cluster. But if doing a node pool upgrade this may be a different version.<br/>  - ami\_release\_version (string): AMI Release version to use for EKS worker nodes. ref: https://github.com/awslabs/amazon-eks-ami/releases<br/>  - ami\_type (string): e.g. AMD64 or ARM<br/>  - spot (bool): Enable spot instances for the nodes. DO NOT ENABLE IN PROD!<br/>  - disk\_size\_gb (number): Disk size in GB for the nodes.<br/>  - max\_pods (number): max pods that can be scheduled per node.<br/>  - ssh\_key\_pair\_names (list(string)): List of SSH key pair names to associate with the nodes. ref: https://us-west-2.console.aws.amazon.com/ec2/home?region=us-west-2#KeyPairs:<br/>  - kubernetes\_labels (map(string)): Map of labels to apply to the nodes. ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/<br/>  - kubernetes\_taints (list(object)): List of taints to apply to the nodes. ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ | <pre>list(object({<br/>    name                = string<br/>    node_count          = number<br/>    instance_type       = string<br/>    kubernetes_version  = string<br/>    ami_release_version = string<br/>    ami_type            = string<br/>    spot                = bool<br/>    disk_size_gb        = number<br/>    max_pods            = number<br/>    ssh_key_pair_names  = list(string)<br/>    kubernetes_labels   = map(string)<br/>    kubernetes_taints = list(object({<br/>      key    = string<br/>      value  = string<br/>      effect = string<br/>    }))<br/><br/>  }))</pre> | <pre>[<br/>  {<br/>    "ami_release_version": "1.31.7-20250620",<br/>    "ami_type": "AL2023_x86_64_STANDARD",<br/>    "disk_size_gb": 20,<br/>    "instance_type": "t3a.large",<br/>    "kubernetes_labels": {},<br/>    "kubernetes_taints": [],<br/>    "kubernetes_version": "1.31",<br/>    "max_pods": 110,<br/>    "name": "default-pool",<br/>    "node_count": 1,<br/>    "spot": false,<br/>    "ssh_key_pair_names": []<br/>  }<br/>]</pre> | no |
 | <a name="input_peering_configs"></a> [peering\_configs](#input\_peering\_configs) | A list of maps containing VPC peering configuration details | <pre>list(object({<br/>    vpc_peering_connection_id = string<br/>    destination_cidr_block    = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_private_subnets_enabled"></a> [private\_subnets\_enabled](#input\_private\_subnets\_enabled) | enable private subnets | `bool` | `false` | no |
 | <a name="input_region"></a> [region](#input\_region) | The AWS region to deploy into | `string` | n/a | yes |

--- a/docs/.header.md
+++ b/docs/.header.md
@@ -37,7 +37,7 @@ module "captain" {
 #    {
 #      "kubernetes_version" : "1.31",
 #      "ami_release_version" : "1.31.7-20250620",
-#      "ami_type" : "AL2_x86_64",
+#      "ami_type" : "AL2023_x86_64_STANDARD",
 #      "instance_type" : "t3a.large",
 #      "name" : "glueops-platform-node-pool-1",
 #      "node_count" : 4,
@@ -59,7 +59,7 @@ module "captain" {
 #    {
 #      "kubernetes_version" : "1.31",
 #      "ami_release_version" : "1.31.7-20250620",
-#      "ami_type" : "AL2_x86_64",
+#      "ami_type" : "AL2023_x86_64_STANDARD",
 #      "instance_type" : "t3a.small",
 #      "name" : "glueops-platform-node-pool-argocd-app-controller-1",
 #      "node_count" : 2,
@@ -81,7 +81,7 @@ module "captain" {
 #    {
 #      "kubernetes_version" : "1.31",
 #      "ami_release_version" : "1.31.7-20250620",
-#      "ami_type" : "AL2_x86_64",
+#      "ami_type" : "AL2023_x86_64_STANDARD",
 #      "instance_type" : "t3a.medium",
 #      "name" : "clusterwide-node-pool-1",
 #      "node_count" : 2,

--- a/glueops-tests/main.tf
+++ b/glueops-tests/main.tf
@@ -22,7 +22,7 @@ module "captain" {
     #    {
     #      "kubernetes_version" : "1.31",
     #      "ami_release_version" : "1.31.7-20250620",
-    #      "ami_type" : "AL2_x86_64",
+    #      "ami_type" : "AL2023_x86_64_STANDARD",
     #      "instance_type" : "t3a.large",
     #      "name" : "glueops-platform-node-pool-1",
     #      "node_count" : 4,
@@ -44,7 +44,7 @@ module "captain" {
     #    {
     #      "kubernetes_version" : "1.31",
     #      "ami_release_version" : "1.31.7-20250620",
-    #      "ami_type" : "AL2_x86_64",
+    #      "ami_type" : "AL2023_x86_64_STANDARD",
     #      "instance_type" : "t3a.small",
     #      "name" : "glueops-platform-node-pool-argocd-app-controller-1",
     #      "node_count" : 2,
@@ -66,7 +66,7 @@ module "captain" {
     #    {
     #      "kubernetes_version" : "1.31",
     #      "ami_release_version" : "1.31.7-20250620",
-    #      "ami_type" : "AL2_x86_64",
+    #      "ami_type" : "AL2023_x86_64_STANDARD",
     #      "instance_type" : "t3a.medium",
     #      "name" : "clusterwide-node-pool-1",
     #      "node_count" : 2,

--- a/variables.tf
+++ b/variables.tf
@@ -112,7 +112,7 @@ variable "node_pools" {
     instance_type       = "t3a.large"
     ami_release_version = "1.31.7-20250620"
     kubernetes_version  = "1.31"
-    ami_type            = "AL2_x86_64"
+    ami_type            = "AL2023_x86_64_STANDARD"
     spot                = false
     disk_size_gb        = 20
     max_pods            = 110


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Update AMI type from AL2_x86_64 to AL2023_x86_64_STANDARD

- Modernize EKS node pool configuration across documentation

- Update default variable values for consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old AMI Type"] -- "upgrade" --> B["AL2023_x86_64_STANDARD"]
  B --> C["Documentation"]
  B --> D["Variables"]
  B --> E["Test Config"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update documentation examples with new AMI type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Update AMI type in three example node pool configurations<br> <li> Change default value in variable documentation table</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster/pull/261/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>.header.md</strong><dd><code>Update header documentation with new AMI type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/.header.md

<ul><li>Update AMI type in three example node pool configurations<br> <li> Maintain consistency with main documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster/pull/261/files#diff-1a920578bc3e05f584ae3733aa0a891fa9af5fbae8afe498215e2df849598eb4">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Update test configuration AMI type references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

glueops-tests/main.tf

<ul><li>Update AMI type in three commented node pool examples<br> <li> Ensure test configuration uses updated AMI type</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster/pull/261/files#diff-b9b7b428f9e731cecb2817beb5e1f18961ef2d057e69298993f6fc6bb749de4e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Update default AMI type in variable definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

variables.tf

<ul><li>Change default AMI type from AL2_x86_64 to AL2023_x86_64_STANDARD<br> <li> Update node_pools variable default value</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster/pull/261/files#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

