### PR TITLE
feat: bump calico version and added peers_config in tests/main.tf

### DIFF
--- a/glueops-tests/calico.yaml
+++ b/glueops-tests/calico.yaml
@@ -40,8 +40,8 @@ podLabels: {}
 # Image and registry configuration for the tigera/operator pod.
 tigeraOperator:
   image: tigera/operator
-  version: v1.36.12
+  version: v1.38.7
   registry: quay.io
 calicoctl:
   image: docker.io/calico/ctl
-  tag: v3.29.5
+  tag: v3.30.4

--- a/glueops-tests/main.tf
+++ b/glueops-tests/main.tf
@@ -77,5 +77,6 @@ module "captain" {
     #      "kubernetes_labels" : {},
     #      "kubernetes_taints" : []
     #    }
-  ]
+  ],
+   peering_configs = []
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Upgrade Calico operator from v1.36.12 to v1.38.7

- Upgrade calicoctl from v3.29.5 to v3.30.4

- Add peering_configs parameter to captain module


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Calico Configuration"] -->|"Operator v1.36.12 → v1.38.7"| B["Updated calico.yaml"]
  A -->|"Calicoctl v3.29.5 → v3.30.4"| B
  C["Captain Module"] -->|"Add peering_configs"| D["Updated main.tf"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>calico.yaml</strong><dd><code>Bump Calico operator and calicoctl versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

glueops-tests/calico.yaml

<ul><li>Upgrade tigera/operator image version from v1.36.12 to v1.38.7<br> <li> Upgrade calicoctl image tag from v3.29.5 to v3.30.4</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster/pull/310/files#diff-d1c8f32c054d47fc655291bef5c7a8995766b95390c763078903113e5eafdabc">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Add peering_configs to captain module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

glueops-tests/main.tf

<ul><li>Add peering_configs parameter to captain module configuration<br> <li> Initialize peering_configs as empty list</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster/pull/310/files#diff-b9b7b428f9e731cecb2817beb5e1f18961ef2d057e69298993f6fc6bb749de4e">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).