### PR TITLE
chore: Update AWS Nuke version to v3.61.0

### DIFF
--- a/glueops-tests/destroy-aws.sh
+++ b/glueops-tests/destroy-aws.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-AWS_NUKE_VERSION=v3.60.0
+AWS_NUKE_VERSION=v3.61.0
 # reference: https://github.com/GlueOps/scripts-teardown-aws-amazon-web-services
 echo "Preform an AWS Cleanup with AWS Nuke"
 wget https://github.com/ekristen/aws-nuke/releases/download/$AWS_NUKE_VERSION/aws-nuke-$AWS_NUKE_VERSION-linux-amd64.tar.gz && tar -xvf aws-nuke-$AWS_NUKE_VERSION-linux-amd64.tar.gz && rm aws-nuke-$AWS_NUKE_VERSION-linux-amd64.tar.gz


### PR DESCRIPTION


> This app will be decommissioned on Dec 1st. Please remove this app and install [Qodo Git](https://github.com/marketplace/qodo-merge-pro).

### **PR Type**
Enhancement


___

### **Description**
- Update AWS Nuke version from v3.60.0 to v3.61.0

- Ensures latest bug fixes and features available


___

### Diagram Walkthrough


```mermaid
flowchart LR
  oldVersion["AWS Nuke v3.60.0"] -- "upgrade" --> newVersion["AWS Nuke v3.61.0"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>destroy-aws.sh</strong><dd><code>Bump AWS Nuke version to v3.61.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

glueops-tests/destroy-aws.sh

<ul><li>Updated <code>AWS_NUKE_VERSION</code> variable from v3.60.0 to v3.61.0<br> <li> Enables the AWS cleanup script to use the latest version</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster/pull/325/files#diff-4eb5d038244c1bca9cf0b3e6e8bbc5b81a13c82f3135c9730646d93c709782f8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).