### PR TITLE
fix: Update Calico CNI version to v3.30.4

### DIFF
--- a/glueops-tests/run.sh
+++ b/glueops-tests/run.sh
@@ -27,7 +27,7 @@ kubectl delete daemonset -n kube-system aws-node
 echo "Install Calico CNI"
 helm repo add projectcalico https://docs.tigera.io/calico/charts
 helm repo update
-helm install calico projectcalico/tigera-operator --version v3.29.5 --namespace tigera-operator -f calico.yaml --create-namespace
+helm install calico projectcalico/tigera-operator --version v3.30.4 --namespace tigera-operator -f calico.yaml --create-namespace
 echo "::endgroup::"
 
 echo "::group::Deploying new Node Pool"


### PR DESCRIPTION


> This app will be decommissioned on Dec 1st. Please remove this app and install [Qodo Git](https://github.com/marketplace/qodo-merge-pro).

### **PR Type**
Bug fix


___

### **Description**
- Update Calico CNI tigera-operator version from v3.29.5 to v3.30.4

- Ensures latest stable Calico release in test environment


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Calico v3.29.5"] -- "version upgrade" --> B["Calico v3.30.4"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>run.sh</strong><dd><code>Bump Calico tigera-operator version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

glueops-tests/run.sh

<ul><li>Updated Calico tigera-operator Helm chart version from v3.29.5 to <br>v3.30.4<br> <li> Maintains same installation parameters and namespace configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-aws-kubernetes-cluster/pull/326/files#diff-c879a56a3eaf701bfb481924b6928be46996ade6be90bf6495d48b2ac135fa84">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).