### PR TITLE
feat: cloudposse module clean batch — vpc 3.0.0, dynamic-subnets 3.1.1, eks-node-group 3.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,9 @@ No requirements.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_kubernetes"></a> [kubernetes](#module\_kubernetes) | cloudposse/eks-cluster/aws | 3.0.0 |
-| <a name="module_node_pool"></a> [node\_pool](#module\_node\_pool) | cloudposse/eks-node-group/aws | 3.1.1 |
-| <a name="module_subnets"></a> [subnets](#module\_subnets) | cloudposse/dynamic-subnets/aws | 2.4.2 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/vpc/aws | 2.2.0 |
+| <a name="module_node_pool"></a> [node\_pool](#module\_node\_pool) | cloudposse/eks-node-group/aws | 3.4.0 |
+| <a name="module_subnets"></a> [subnets](#module\_subnets) | cloudposse/dynamic-subnets/aws | 3.1.1 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/vpc/aws | 3.0.0 |
 | <a name="module_vpc_peering_accepter_with_routes"></a> [vpc\_peering\_accepter\_with\_routes](#module\_vpc\_peering\_accepter\_with\_routes) | ./modules/vpc_peering_accepter_with_routes | n/a |
 
 ## Resources

--- a/network.tf
+++ b/network.tf
@@ -1,7 +1,7 @@
 module "vpc" {
   source = "cloudposse/vpc/aws"
   # Cloud Posse recommends pinning every module to a specific version
-  version                 = "2.2.0"
+  version                 = "3.0.0"
   ipv4_primary_cidr_block = local.vpc.cidr_block
   name                    = "captain"
 }
@@ -10,7 +10,7 @@ module "vpc" {
 module "subnets" {
   source = "cloudposse/dynamic-subnets/aws"
   # Cloud Posse recommends pinning every module to a specific version
-  version = "2.4.2"
+  version = "3.1.1"
 
   vpc_id                         = module.vpc.vpc_id
   igw_id                         = [module.vpc.igw_id]

--- a/node_pool.tf
+++ b/node_pool.tf
@@ -3,7 +3,7 @@ module "node_pool" {
   for_each = { for np in var.node_pools : np.name => np }
   source   = "cloudposse/eks-node-group/aws"
   # Cloud Posse recommends pinning every module to a specific version
-  version               = "3.1.1"
+  version               = "3.4.0"
   ec2_ssh_key_name      = each.value.ssh_key_pair_names
   instance_types        = [each.value.instance_type]
   subnet_ids            = var.private_subnets_enabled ? module.subnets.private_subnet_ids : module.subnets.public_subnet_ids


### PR DESCRIPTION
## Summary

Combined **clean** upgrade of the three Cloud Posse modules that move with **no functional changes** (tags only). Consolidates renovate PRs #368, #367, #365.

| Module | From | To | Impact |
|---|---|---|---|
| cloudposse/vpc/aws | 2.2.0 | **3.0.0** | No-op — only the unused `vpc-endpoints` submodule changed; root module byte-identical |
| cloudposse/dynamic-subnets/aws | 2.4.2 | **3.1.1** | Still `count`-indexed → no `moved{}` blocks; NAT & no-NAT math verified equivalent |
| cloudposse/eks-node-group/aws | 3.1.1 | **3.4.0** | In-place node-group tag additions (autoscaler label/taint tags) + no-op `node_repair_config{false}`; adds `hashicorp/null` provider req (auto-resolved) |

## Verification (live cluster, account `184515722743`, both NAT & no-NAT)

- **no-NAT in-place upgrade** from the previous versions: plan = **1 add** (infra-free `null_resource.seq`) + **1 in-place** (node-group autoscaler tags + no-op `node_repair_config`), **0 destroy**. Nodes **not** replaced. **Zero drift** on re-plan after apply.
- **fresh NAT deploy**: 53 resources; worker nodes land in **private** subnets routing through **per-AZ NAT gateways**; public subnets reserved for ELBs; **zero drift** on re-plan.

## Upgrade path for existing users

`terraform init -upgrade` then `apply`. **No `moved{}` blocks, no state surgery, no node replacement.** The only apply-time change is the node-group autoscaler tag + a no-op config block.

## Not included

`cloudposse/eks-cluster/aws` 3.0.0 → 4.10.0 (#373) is **intentionally excluded** — it is a breaking change (aws-auth → EKS access entries; removed inputs `apply_config_map_aws_auth`/`vpc_id`; removed output `kubernetes_config_map_id`; forces `authentication_mode` change + SG-rule recreate). It needs a dedicated migration PR.

Supersedes/closes: #368, #367, #365 (rolled up here) and duplicate bumps #376, #375, #374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)